### PR TITLE
Fixing TypeError

### DIFF
--- a/tests_chapter7.py
+++ b/tests_chapter7.py
@@ -85,7 +85,7 @@ class Chapter7LiveServerTestCase(StaticLiveServerTestCase):
         url_path = self.browser.current_url
         response = self.client.get(url_path)
 
-        self.assertIn('required'.lower(), response.content.lower())
+        self.assertIn('required'.lower(), response.content.decode('ascii').lower())
 
     @chapter7
     def test_add_category_that_already_exists(self):


### PR DESCRIPTION
Without decoding the response.content, a type error was always raised:

TypeError: a bytes-like object is required, not 'str'

By adding this decode step, it matches other assert methods comparing a string to the content of a response object and the type error is no longer raised.